### PR TITLE
Make existsFolder(name) and FileExists(name) methods public

### DIFF
--- a/APIAlfresco.php
+++ b/APIAlfresco.php
@@ -435,9 +435,8 @@ class APIAlfresco
 
     /*
     *
-    *	Internal Use
+    *  Check if folder already exists before creating it
     *
-    *	check if the folder already exists before to create it
     */
 
     /**
@@ -447,7 +446,7 @@ class APIAlfresco
      *
      * @return bool True if exists folder, False otherwise.
      */
-    private function existsFolder($name)
+    public function existsFolder($name)
     {
         $obj = $this->repository->getChildren($this->parentFolder->id);
         $name = str_replace('(', '', $name);
@@ -470,13 +469,13 @@ class APIAlfresco
     }
 
     /**
-     * Determines if exists file.
+     * Determines if file exists.
      *
      * @param string $name
      *
      * @return bool
      */
-    private function FileExists($name)
+    public function FileExists($name)
     {
         $obj = $this->repository->getChildren($this->parentFolder->id);
         $name = str_replace('(', '', $name);


### PR DESCRIPTION
Now **existsFolder(name)** and **FileExists(name)** methods are _public_ so programmers can check themselves (in their PHP code) if a given folder/file does already exist. This way, programmers can inform end users with proper messages and help them better than just throwing an Exception error if user is trying to create an already existing folder/file.