### PR TITLE
Special characters handled within the library so programmers don't have to take care of it

### DIFF
--- a/APIAlfresco.php
+++ b/APIAlfresco.php
@@ -94,6 +94,8 @@ class APIAlfresco
     public function setFolderByPath($folder, array $options = array())
     {
         try {
+
+            $folder = $this->extractSpecialCharacters($folder);
             $obj = $this->repository->getObjectByPath($folder, $options);
             $properties = $obj->properties['cmis:baseTypeId'];
             if ($properties != 'cmis:folder') {
@@ -140,12 +142,35 @@ class APIAlfresco
      */
     public function createFolder($name, array $properties = array(), array $options = array())
     {
+        $name = $this->extractSpecialCharacters($name);
         $exists = $this->existsFolder($name);
         if ($exists) {
             throw new Exception('Error:->The folder named '.$name.' already exists', 1);
         }
 
         return $this->repository->createFolder($this->parentFolder->id, $name);
+    }
+
+    /*
+    * Method extractSpecialCharacters(name) replaces spaces with sybmol '%20'.
+    * But then in some cases we need to ensure that folder or files
+    * contain ' ' and not '%20'. Otherwise, i.e., we'd be creating "My%20Folder"
+    * instead of "My Folder" (same with files).
+    *
+    * With proper use of this method, users will be able to create folders
+    * or files with blank spaces.
+    *
+    * @example $name = "My%20Folder%20With%20Spaces";
+    *
+    * @param string $name
+    *
+    * @return  string $name ()= "My Folder With Spaces")
+    */
+    private function getBlankSpacesBack($name){
+
+      $name = str_replace('%20', ' ', $name);
+
+      return $name;
     }
 
     /**
@@ -448,6 +473,8 @@ class APIAlfresco
      */
     public function existsFolder($name)
     {
+        $name = $this->extractSpecialCharacters($name); //remove special chars (keep in mind spaces are now "%20")
+        $name = $this->getBlankSpacesBack($name); //Ensure name is something like "My Folder" and not "My%20Folder"
         $obj = $this->repository->getChildren($this->parentFolder->id);
         $name = str_replace('(', '', $name);
         $name = str_replace(')', '', $name);
@@ -477,6 +504,8 @@ class APIAlfresco
      */
     public function FileExists($name)
     {
+        $name = $this->extractSpecialCharacters($name); //remove special chars (keep in mind spaces are now "%20")
+        $name = $this->getBlankSpacesBack($name); //Ensure name is something like "My Folder" and not "My%20Folder"
         $obj = $this->repository->getChildren($this->parentFolder->id);
         $name = str_replace('(', '', $name);
         $name = str_replace(')', '', $name);


### PR DESCRIPTION
Now methods **FileExists(name)**, **existsFolder(name)**, **setFolderByPath(name)**, **createFolder(name)**, and **createFile(name)** extract special characters making proper call of method _extractEspecialCharacters(name)_. This last method has been modified to also extract symbol '-' and replace blank spaces with '%20' (valid for HTTP requests). Also this method now doesn't extract symbol '/' since it was being conflictive with URLs (this should be fixed in future commits). Also, a method called **getBlankSpacesBack(name)** has been coded. This method is used to replace '%20' back to blank spaces, just in case we need to extract special chars but then don't need blank spaces to be replaced by '%20' (otherwise, i.e., we'd be creating 'My%20Folder' in Alfresco and not 'My Folder'.

P.S: There might be some other methods that I haven't used (or noticed) that also need to handle special characters. If there's any other method with need of handling special characters, just let me know and I'll work on it. Also let me know if you see any error in my fix.

Thanks!