### PR TITLE
Compare repo file/folder names with new file/folder names as lower-case (Alfresco repository isn't case-sensitive)

### DIFF
--- a/APIAlfresco.php
+++ b/APIAlfresco.php
@@ -483,7 +483,8 @@ class APIAlfresco
         $c = 0;
         while ($continue and $c < count($obj->objectList)) {
             if ($obj->objectList[$c]->properties['cmis:objectTypeId'] == 'cmis:folder') {
-                if ($obj->objectList[$c]->properties['cmis:name'] == $name) {
+                //repo folder names and $name parameter will be forced to be lower case (Alfresco folder names aren't case-sensitive)
+                if ( strtolower($obj->objectList[$c]->properties['cmis:name']) == strtolower($name) ) {
                     $continue = false;
                 }
             }
@@ -514,7 +515,8 @@ class APIAlfresco
         $c = 0;
         while ($continue and $c < count($obj->objectList)) {
             if ($obj->objectList[$c]->properties['cmis:objectTypeId'] == 'cmis:document') {
-                if ($obj->objectList[$c]->properties['cmis:name'] == $name) {
+                //repo file names and $name parameter will be forced to be lower case (Alfresco file names aren't case-sensitive)
+                if ( strtolower($obj->objectList[$c]->properties['cmis:name']) == strtolower($name) ) {
                     $continue = false;
                 }
             }

--- a/APIAlfresco.php
+++ b/APIAlfresco.php
@@ -210,6 +210,7 @@ class APIAlfresco
     {
         $name = basename($file);
         $name = $this->extractSpecialCharacters($name);
+        $name = $this->getBlankSpacesBack($name);
         $openFile = fopen($file, 'r');
         $content = fread($openFile, filesize($file));
         //You need to activate fileinfo


### PR DESCRIPTION
**fileExists(name)** and **existsFolder(name)** now work with lower-case strings since in Alfresco file and folder names are not case-sensitive. Before this fix, if there was a folder named "My Folder" (with upper-cases) in Alfresco, and we called **existsFolder("my folder")**, parameter being all lower-case, this method would return false since "My Folder" does not equal to "my folder".

If you then tried to create a folder named "my folder" (it theoretically did not exist) it would fail since in Alfresco "My Folder" and "my folder" would be treated as the same folder. Equal comparison was like:

`if(repoFolder == newFolder){ ... }`

But now this comparison is something like:

` if(strtolower(repoFolder) == strtolower(newFolder) { ... }`

Sames goes with files.
